### PR TITLE
ServiceMonitor cannot be toggled

### DIFF
--- a/servicemonitor.yaml
+++ b/servicemonitor.yaml
@@ -1,7 +1,7 @@
 #@ load("@ytt:data", "data")
 #@ load("config.lib.yaml", "name", "fullName", "chart", "labels", "selectorLabels")
 
-#@ if data.values.serviceMonitor:
+#@ if data.values.serviceMonitor.enabled:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Guessing a typo, the toggle should be put in place by the `enabled` key rather than the structure.